### PR TITLE
Refactoring: Serialization and transport cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,14 @@ keywords = ["bitcoin", "vault", "Noise", "transport"]
 description = "Transport and messages implementation of the version 0 Revault protocol"
 exclude = [".github/", "fuzz"]
 
+[features]
+# Get access to internal APIs from the fuzzing framework
+fuzz = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
 revault_tx = { version = "0.2", features = ["use-serde"] }
 bitcoin = { version = "0.26", features = ["use-serde"] }
 snow = { version = "0.7", default-features = false, features = ["libsodium-resolver"] }
@@ -19,6 +24,4 @@ snow = { version = "0.7", default-features = false, features = ["libsodium-resol
 # Used for Noise crypto and generating pubkeys
 sodiumoxide = { version = "0.2", features = ["serde"] }
 
-
-[dev-dependencies]
-serde_json = "1.0"
+log = "0.4"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,3 +1,3 @@
-
+corpus
 target
 artifacts

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
 name = "bitcoin"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aefc9be9f17185f4ebccae6575d342063f775924d57df0000edb1880c0fb7095"
+checksum = "1ec5f88a446d66e7474a3b8fa2e348320b574463fb78d799d90ba68f79f48e0e"
 dependencies = [
  "bech32",
  "bitcoin_hashes",
@@ -64,6 +64,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
 name = "libc"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,13 +103,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniscript"
-version = "4.0.3"
+name = "log"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ff4ece4ff5498718a232e92d53273903609c739052f5edf2a1a42c59586348"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "miniscript"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f455be59a359d50370c4f587afbc5739c862e684c5afecae80ab93e7474b4e"
 dependencies = [
  "bitcoin",
- "serde",
 ]
 
 [[package]]
@@ -134,8 +154,11 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 name = "revault_net"
 version = "0.0.1"
 dependencies = [
+ "bitcoin",
+ "log",
  "revault_tx",
  "serde",
+ "serde_json",
  "snow",
  "sodiumoxide",
 ]
@@ -151,8 +174,9 @@ dependencies = [
 
 [[package]]
 name = "revault_tx"
-version = "0.0.1"
-source = "git+https://github.com/re-vault/revault_tx#4cae12528cc8c148b463cf92e244004d49351402"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281109ba2c34a241b24e30e22225c4fd283a5dc69f86c33de9cc339abb870c38"
 dependencies = [
  "base64",
  "bitcoinconsensus",
@@ -170,10 +194,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.19.0"
+name = "ryu"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "secp256k1"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733b114f058f260c0af7591434eef4272ae1a8ec2751766d3cb89c6df8d5e450"
 dependencies = [
  "secp256k1-sys",
  "serde",
@@ -181,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
+checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
 dependencies = [
  "cc",
 ]
@@ -221,6 +251,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ sodiumoxide = { version = "0.2", features = ["serde"] }
 
 [dependencies.revault_net]
 path = ".."
+features = ["fuzz"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/transport.rs
+++ b/fuzz/fuzz_targets/transport.rs
@@ -30,11 +30,11 @@ fn kk_client_server(data: &[u8]) {
     thread::spawn(move || {
         let mut cli_channel = KKTransport::connect(addr, &INIT_PRIVKEY, &RESP_PUBKEY)
             .expect("Client channel connecting");
-        cli_channel.write(&msg_sent).expect("Sending test message");
+        cli_channel.pubwrite(&msg_sent).expect("Sending test message");
     });
 
     let mut serv_transport = KKTransport::accept(&listener, &RESP_PRIVKEY, &[INIT_PUBKEY]).unwrap();
-    if let Ok(msg) = serv_transport.read() {
+    if let Ok(msg) = serv_transport.pubread() {
         assert_eq!(msg, data);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,7 +42,7 @@ impl error::Error for NoiseError {}
 /// An error enum for revault_net functionality
 #[derive(Debug)]
 pub enum Error {
-    /// Error while using noise API
+    /// Noise protocol related error
     Noise(NoiseError),
     /// Transport error
     Transport(std::io::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     Noise(NoiseError),
     /// Transport error
     Transport(std::io::Error),
+    /// JSON serialization / deserialization error.
+    Json(serde_json::Error),
 }
 
 impl fmt::Display for Error {
@@ -53,6 +55,7 @@ impl fmt::Display for Error {
         match *self {
             Error::Noise(ref e) => write!(f, "Noise Error: {}", e),
             Error::Transport(ref e) => write!(f, "Transport Error: {}", e),
+            Error::Json(ref e) => write!(f, "Json error: '{}'", e),
         }
     }
 }
@@ -68,5 +71,11 @@ impl From<std::io::Error> for Error {
 impl From<NoiseError> for Error {
     fn from(error: NoiseError) -> Self {
         Self::Noise(error)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,48 +8,99 @@
 
 use serde::{Deserialize, Serialize};
 
-/// A JSON request object that conforms to the specification in practical-revault
+/// A JSONRPC-like request, as specified in [practical-revault](https://github.com/revault/practical-revault/blob/master/messages.md)
+#[allow(missing_docs)]
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-pub struct Request<'a, T> {
-    /// Method name as in practical-revault
-    method: &'a str,
-    /// Parameters encapsulated with the associated message struct
-    params: T,
+#[serde(untagged)]
+pub enum Request<'a> {
+    WtSig {
+        method: &'a str,
+        params: watchtower::Sig,
+    },
+    SetSpendTx {
+        method: &'a str,
+        params: coordinator::SetSpendTx,
+    },
+    GetSpendTx {
+        method: &'a str,
+        params: coordinator::GetSpendTx,
+    },
+    CoordSig {
+        method: &'a str,
+        params: coordinator::Sig,
+    },
+    GetSigs {
+        method: &'a str,
+        params: coordinator::GetSigs,
+    },
+    Sign {
+        method: &'a str,
+        params: cosigner::SignRequest,
+    },
 }
 
-/// A JSON response object that conforms to the specification in practical-revault
-#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-pub struct Response<RevaultResponse> {
-    /// Result of the response message
-    pub result: RevaultResponse,
+impl<'a> Request<'a> {
+    /// Get the parameters of this request
+    pub fn params(self) -> RequestParams {
+        match self {
+            Request::WtSig { params, .. } => RequestParams::WtSig(params),
+            Request::SetSpendTx { params, .. } => RequestParams::SetSpendTx(params),
+            Request::GetSpendTx { params, .. } => RequestParams::GetSpendTx(params),
+            Request::CoordSig { params, .. } => RequestParams::CoordSig(params),
+            Request::GetSigs { params, .. } => RequestParams::GetSigs(params),
+            Request::Sign { params, .. } => RequestParams::Sign(params),
+        }
+    }
 }
 
+/// All params types that can possibly be sent through a Request
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RequestParams {
+    WtSig(watchtower::Sig),
+    SetSpendTx(coordinator::SetSpendTx),
+    GetSpendTx(coordinator::GetSpendTx),
+    CoordSig(coordinator::Sig),
+    GetSigs(coordinator::GetSigs),
+    Sign(cosigner::SignRequest),
+}
+
+// Implement From(param type) for a Request
 macro_rules! impl_to_request {
-    ($message_struct:ident, $message_name:literal) => {
-        impl From<$message_struct> for Request<'_, $message_struct> {
-            fn from(msg: $message_struct) -> Self {
-                Self {
+    ($message_struct:ident, $message_name:literal, $enum_variant:ident) => {
+        impl From<$message_struct> for Request<'_> {
+            fn from(params: $message_struct) -> Self {
+                Self::$enum_variant {
                     method: $message_name,
-                    params: msg,
+                    params,
                 }
             }
         }
     };
 }
 
-macro_rules! impl_to_response {
-    ($message_struct:ident) => {
-        impl From<$message_struct> for Response<$message_struct> {
-            fn from(msg: $message_struct) -> Self {
-                Self { result: msg }
-            }
-        }
-    };
+/// All result types that can possibly be returned by a Response
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ResponseResult {
+    SigAck(watchtower::SigAck),
+    Sigs(coordinator::Sigs),
+    SpendTx(coordinator::SpendTx),
+    SignResult(cosigner::SignResult),
+}
+
+/// A JSONRPC-like response, as specified in [practical-revault](https://github.com/revault/practical-revault/blob/master/messages.md)
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct Response<T> {
+    pub result: T,
 }
 
 /// Messages related to the communication with the Watchtower(s)
 pub mod watchtower {
-    use super::{Deserialize, Request, Response, Serialize};
+    use super::{Deserialize, Request, Serialize};
     use bitcoin::{
         hash_types::Txid,
         secp256k1::{key::PublicKey, Signature},
@@ -70,7 +121,7 @@ pub mod watchtower {
         /// Deposit outpoint of this vault
         pub deposit_outpoint: OutPoint,
     }
-    impl_to_request!(Sig, "sig");
+    impl_to_request!(Sig, "sig", WtSig);
 
     /// Message from the watchtower to stakeholder to acknowledge that it has
     /// sufficient signatures and fees to begin guarding the vault with the
@@ -82,12 +133,11 @@ pub mod watchtower {
         /// Revocation transaction id
         pub txid: Txid,
     }
-    impl_to_response!(SigAck);
 }
 
 /// Messages related to the communication with the Coordinator
 pub mod coordinator {
-    use super::{Deserialize, Request, Response, Serialize};
+    use super::{Deserialize, Request, Serialize};
     use bitcoin::{
         hash_types::Txid,
         secp256k1::{key::PublicKey, Signature},
@@ -132,7 +182,6 @@ pub mod coordinator {
         /// transaction.
         pub signatures: BTreeMap<PublicKey, Signature>,
     }
-    impl_to_response!(Sigs);
 
     /// Sent by a manager to advertise the spend transaction that will eventually
     /// be used for a specific unvault.
@@ -144,7 +193,7 @@ pub mod coordinator {
         #[serde(with = "serde_tx_hex")]
         transaction: Transaction,
     }
-    impl_to_request!(SetSpendTx, "set_spend_tx");
+    impl_to_request!(SetSpendTx, "set_spend_tx", SetSpendTx);
 
     impl SetSpendTx {
         /// Create a SetSpendTx message out of a SpendTransaction.
@@ -173,7 +222,7 @@ pub mod coordinator {
         /// spend tx is spending.
         pub deposit_outpoint: OutPoint,
     }
-    impl_to_request!(GetSpendTx, "get_spend_tx");
+    impl_to_request!(GetSpendTx, "get_spend_tx", GetSpendTx);
 
     /// The response to the [GetSpendTx] request.
     #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -183,7 +232,6 @@ pub mod coordinator {
         #[serde(with = "serde_tx_hex")]
         pub transaction: Transaction,
     }
-    impl_to_response!(SpendTx);
 
     /// Message from a stakeholder client to sync server to share (at any time)
     /// the signature for a revocation transaction with all participants.
@@ -196,7 +244,7 @@ pub mod coordinator {
         /// Txid of the transaction the signature applies to
         pub id: Txid,
     }
-    impl_to_request!(Sig, "sig");
+    impl_to_request!(Sig, "sig", CoordSig);
 
     /// Sent by a wallet to retrieve all signatures for a specific transaction
     #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -204,44 +252,12 @@ pub mod coordinator {
         /// Transaction id
         pub id: Txid,
     }
-    impl_to_request!(GetSigs, "get_sigs");
-
-    /// A message sent from a stakeholder to the Coordinator
-    #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-    #[serde(untagged)]
-    pub enum FromStakeholder {
-        /// Stakeholders can push signatures
-        Sig(Sig),
-        /// Stakeholders can fetch signatures
-        GetSigs(GetSigs),
-    }
-
-    /// A message sent from a manager to the Coordinator
-    #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-    #[serde(untagged)]
-    pub enum FromManager {
-        /// Managers can set a spend transaction
-        SetSpend(SetSpendTx),
-        /// Managers can fetch pre-signed transaction signatures
-        GetSigs(GetSigs),
-    }
-
-    /// A message sent from either a manager or a stakeholder to the Coordinator
-    #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-    #[serde(untagged)]
-    pub enum FromParticipant {
-        /// Stakeholders can push signatures
-        Sig(Sig),
-        /// Managers can set a spend transaction
-        SetSpend(SetSpendTx),
-        /// Both can fetch signatures
-        GetSigs(GetSigs),
-    }
+    impl_to_request!(GetSigs, "get_sigs", GetSigs);
 }
 
 /// Messages related to the communication with the Cosigning Server(s)
 pub mod cosigner {
-    use super::{Deserialize, Request, Response, Serialize};
+    use super::{Deserialize, Request, Serialize};
     use revault_tx::transactions::SpendTransaction;
     use std::convert::From;
 
@@ -252,21 +268,20 @@ pub mod cosigner {
         /// The partially signed unvault transaction
         pub tx: SpendTransaction,
     }
-    impl_to_request!(SignRequest, "sign");
+    impl_to_request!(SignRequest, "sign", Sign);
 
     /// Message returned from the cosigning server to the manager containing
     /// the requested signature
     #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-    pub struct SignResponse {
+    pub struct SignResult {
         /// Cosigning server's signature for the unvault transaction
         pub tx: Option<SpendTransaction>,
     }
-    impl_to_response!(SignResponse);
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Request, Response};
+    use super::{Request, Response, ResponseResult};
     use std::{collections::BTreeMap, str::FromStr};
 
     use revault_tx::{
@@ -354,7 +369,7 @@ mod tests {
         let ack = true;
         let txid = Txid::default();
         let msg = Response {
-            result: watchtower::SigAck { ack, txid },
+            result: ResponseResult::SigAck(watchtower::SigAck { ack, txid }),
         };
         roundtrip!(msg);
         assert_str_ser!(
@@ -380,9 +395,9 @@ mod tests {
 
         // Response
         let msg = Response {
-            result: coordinator::SpendTx {
+            result: ResponseResult::SpendTx(coordinator::SpendTx {
                 transaction: get_dummy_spend_tx().into_psbt().extract_tx(),
-            },
+            }),
         };
         eprintln!("{}", get_dummy_spend_tx().hex());
         roundtrip!(msg);
@@ -431,7 +446,7 @@ mod tests {
 
         // With signatures
         let msg = Response {
-            result: coordinator::Sigs { signatures },
+            result: ResponseResult::Sigs(coordinator::Sigs { signatures }),
         };
         roundtrip!(msg);
         assert_str_ser!(
@@ -442,7 +457,7 @@ mod tests {
         // Without signatures
         let signatures = BTreeMap::new();
         let msg = Response {
-            result: coordinator::Sigs { signatures },
+            result: ResponseResult::Sigs(coordinator::Sigs { signatures }),
         };
         roundtrip!(msg);
         assert_str_ser!(msg, r#"{"result":{"signatures":{}}}"#);
@@ -476,7 +491,7 @@ mod tests {
         );
 
         let tx = Some(get_dummy_spend_tx());
-        let msg = cosigner::SignResponse { tx };
+        let msg = cosigner::SignResult { tx };
         roundtrip!(msg);
         assert_str_ser!(
             msg,
@@ -484,7 +499,7 @@ mod tests {
         );
 
         let msg = Response {
-            result: cosigner::SignResponse { tx: None },
+            result: ResponseResult::SignResult(cosigner::SignResult { tx: None }),
         };
         roundtrip!(msg);
         assert_str_ser!(msg, r#"{"result":{"tx":null}}"#);

--- a/src/message.rs
+++ b/src/message.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub struct Request<'a, RevaultRequest> {
     /// Method name as in practical-revault
-    pub method: &'a str,
+    method: &'a str,
     /// Parameters encapsulated with the associated message struct
-    pub params: RevaultRequest,
+    params: RevaultRequest,
 }
 
 /// A JSON response object that conforms to the specification in practical-revault

--- a/src/message.rs
+++ b/src/message.rs
@@ -37,9 +37,19 @@ macro_rules! impl_to_request {
     };
 }
 
+macro_rules! impl_to_response {
+    ($message_struct:ident) => {
+        impl From<$message_struct> for Response<$message_struct> {
+            fn from(msg: $message_struct) -> Self {
+                Self { result: msg }
+            }
+        }
+    };
+}
+
 /// Messages related to the communication with the Watchtower(s)
 pub mod watchtower {
-    use super::{Deserialize, Request, Serialize};
+    use super::{Deserialize, Request, Response, Serialize};
     use bitcoin::{
         hash_types::Txid,
         secp256k1::{key::PublicKey, Signature},
@@ -72,11 +82,12 @@ pub mod watchtower {
         /// Revocation transaction id
         pub txid: Txid,
     }
+    impl_to_response!(SigAck);
 }
 
 /// Messages related to the communication with the Coordinator
 pub mod coordinator {
-    use super::{Deserialize, Request, Serialize};
+    use super::{Deserialize, Request, Response, Serialize};
     use bitcoin::{
         hash_types::Txid,
         secp256k1::{key::PublicKey, Signature},
@@ -121,6 +132,7 @@ pub mod coordinator {
         /// transaction.
         pub signatures: BTreeMap<PublicKey, Signature>,
     }
+    impl_to_response!(Sigs);
 
     /// Sent by a manager to advertise the spend transaction that will eventually
     /// be used for a specific unvault.
@@ -171,6 +183,7 @@ pub mod coordinator {
         #[serde(with = "serde_tx_hex")]
         pub transaction: Transaction,
     }
+    impl_to_response!(SpendTx);
 
     /// Message from a stakeholder client to sync server to share (at any time)
     /// the signature for a revocation transaction with all participants.
@@ -228,7 +241,7 @@ pub mod coordinator {
 
 /// Messages related to the communication with the Cosigning Server(s)
 pub mod cosigner {
-    use super::{Deserialize, Request, Serialize};
+    use super::{Deserialize, Request, Response, Serialize};
     use revault_tx::transactions::SpendTransaction;
     use std::convert::From;
 
@@ -248,6 +261,7 @@ pub mod cosigner {
         /// Cosigning server's signature for the unvault transaction
         pub tx: Option<SpendTransaction>,
     }
+    impl_to_response!(SignResponse);
 }
 
 #[cfg(test)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -10,11 +10,11 @@ use serde::{Deserialize, Serialize};
 
 /// A JSON request object that conforms to the specification in practical-revault
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-pub struct Request<'a, RevaultRequest> {
+pub struct Request<'a, T> {
     /// Method name as in practical-revault
     method: &'a str,
     /// Parameters encapsulated with the associated message struct
-    params: RevaultRequest,
+    params: T,
 }
 
 /// A JSON response object that conforms to the specification in practical-revault


### PR DESCRIPTION
This builds on top of #46 to correct, clean up and refactor our message handling leveraging the new `Request` and `Response`.

This mainly:
- Corrects read() and write() by removing the retry logic (for now, maybe we'll add it back later for `send_req`)
- Abstracts out the read and writing through the transport. We don't read() and write() anymore, we send or receive a request or a response

The main upcoming followups are:
- Integration of a response for each request (needs to be in practical-revault first)
- Integration of ids, i think random numbers would just be fine but i'm still hesitating..