### PR TITLE
Make KKTransport::connect handle TcpStream directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 fuzz/corpus
+target/

--- a/fuzz/fuzz_targets/transport.rs
+++ b/fuzz/fuzz_targets/transport.rs
@@ -30,10 +30,14 @@ fn kk_client_server(data: &[u8]) {
     thread::spawn(move || {
         let mut cli_channel = KKTransport::connect(addr, &INIT_PRIVKEY, &RESP_PUBKEY)
             .expect("Client channel connecting");
-        cli_channel.pubwrite(&msg_sent).expect("Sending test message");
+        cli_channel
+            .pubwrite(&msg_sent)
+            .expect("Sending test message");
     });
 
-    let mut serv_transport = KKTransport::accept(&listener, &RESP_PRIVKEY, &[INIT_PUBKEY]).unwrap();
+    let (connection, _) = listener.accept().unwrap();
+    let mut serv_transport =
+        KKTransport::accept(connection, &RESP_PRIVKEY, &[INIT_PUBKEY]).unwrap();
     if let Ok(msg) = serv_transport.pubread() {
         assert_eq!(msg, data);
     }


### PR DESCRIPTION
Giving the TcpListener as argument to KKTransport
increases the probability of the user making the following mistake:

```rust
loop {
        let transport = KKTransport::accept(&listener, &noise_secret, &client_pubkeys);
        // While KKTransport::accept is blocking because it needs to read in the
        // stream to do the handshake, the loop is not running and the listener is
        // not accepting new connection.
        thread::spawn(move ||
                match transport {
                        ...
                }
        );
}
```

Instead User should himself handle the TcpListener incoming connection in the
code.

```rust
for connection in listener.incoming() {
        if let Ok(connection) = connection {
                thread::spawn(move ||
                        let transport = KKTransport::accept(connection, &noise_secret, &client_pubkeys);
                        match transport {
                        ...
                        }
                );
        }
}

```